### PR TITLE
0.3.11 -> main

### DIFF
--- a/core/NemesisCommon.h
+++ b/core/NemesisCommon.h
@@ -25,7 +25,7 @@ namespace nemesis { namespace core {
 namespace fs = std::filesystem;
 
 
-static const char * NEMESIS_VERSION = "0.3.10";
+static const char * NEMESIS_VERSION = "0.3.11";
 static const std::size_t NEMESIS_CONFIG_VERSION = 1U;
 static const std::size_t NEMESIS_MAX_CORES = 4U;
 

--- a/core/kv/KvPoolWorker.h
+++ b/core/kv/KvPoolWorker.h
@@ -702,7 +702,7 @@ public:
 
 private:
   PoolId m_poolId;
-  std::atomic_bool m_run; // TODO this doesn't need to be atomic, stop() just closes channel?
+  std::atomic_bool m_run; // atomic because destructor called from main thread
   std::jthread m_thread;
   boost::fibers::buffered_channel<KvCommand> m_channel;  
 };

--- a/core/kv/KvSessions.h
+++ b/core/kv/KvSessions.h
@@ -232,7 +232,9 @@ public:
 
 private:
   SessionsMap m_sessions;
-  std::multimap<SessionExpireTime, ExpiryTracking> m_expiry; // TODO consider priority queue
+  std::multimap<SessionExpireTime, ExpiryTracking> m_expiry;
+  // using priority_queue introduces complexities for updateExpiry() because it is not simple to update the priority_queue from the Session.
+  // more work needed, put aside for now 
 };
 
 


### PR DESCRIPTION
v0.3.11 originally to replace `std::map` in `KvSessions` with a `priority_queue` but this requires more changes than initially expected, so put aside from now.